### PR TITLE
fix lint warning

### DIFF
--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
-import { ThemeContext } from '@themes/themeContext'
+import { ThemeContext, ThemeContextType } from '@themes/themeContext'
 import { BaseTheme } from '../themes'
 
 export type Theme = BaseTheme
-export const useTheme = () => useContext(ThemeContext)
+export const useTheme = (): ThemeContextType => useContext(ThemeContext)

--- a/src/saga/index.ts
+++ b/src/saga/index.ts
@@ -1,4 +1,4 @@
-import { Dispatch, applyMiddleware, createStore } from 'redux'
+import { CombinedState, Dispatch, Store, applyMiddleware, createStore } from 'redux'
 import {
   TypedUseSelectorHook,
   useDispatch as useReduxDispatch,
@@ -16,7 +16,7 @@ export const history = createBrowserHistory()
 
 const sagaMiddleware = createSagaMiddleware()
 
-export const configureStore = (preloadedState?: State) => {
+export const configureStore = (preloadedState?: State): Store<CombinedState<State>> => {
   const middlewares = [routerMiddleware(history), sagaMiddleware]
   const middlewareEnhancer = applyMiddleware(...middlewares)
   const store = createStore(rootReducer(history), preloadedState, middlewareEnhancer)

--- a/src/saga/reducers/index.ts
+++ b/src/saga/reducers/index.ts
@@ -1,5 +1,5 @@
 import { History } from 'history'
-import { combineReducers } from 'redux'
+import { CombinedState, Reducer, combineReducers } from 'redux'
 import { RouterState, connectRouter } from 'connected-react-router'
 
 import { NetworkState, networkReducer } from './network'
@@ -9,7 +9,7 @@ export type State = {
   network: NetworkState
 }
 
-export const rootReducer = (history: History) =>
+export const rootReducer = (history: History): Reducer<CombinedState<State>> =>
   combineReducers({
     router: connectRouter(history),
     network: networkReducer,

--- a/src/saga/sagas/index.ts
+++ b/src/saga/sagas/index.ts
@@ -1,5 +1,5 @@
-import { all } from 'redux-saga/effects'
+import { AllEffect, ForkEffect, all } from 'redux-saga/effects'
 
-export const rootSaga = function* root() {
+export const rootSaga = function* root(): Generator<AllEffect<ForkEffect<void>>, void> {
   yield all([])
 }

--- a/src/themes/themeContext.ts
+++ b/src/themes/themeContext.ts
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { ColorMode } from './index'
 
-type ThemeContextType = {
+export type ThemeContextType = {
   colorMode: ColorMode
   setColorMode: () => void
 }


### PR DESCRIPTION
fix @typescript-eslint/explicit-module-boundary-types rules by adjust return types